### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,10 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,7 @@
 name: Java CI with Maven
 
 permissions:
-  contents: read
+  contents: write
   security-events: write
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/danielgp-eu/javajava/security/code-scanning/2](https://github.com/danielgp-eu/javajava/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and uploads a dependency graph. Therefore, we will set `contents: read` and `security-events: write` (required for the dependency graph upload). This ensures no unnecessary write permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
